### PR TITLE
Adjust array keys to account for table changes

### DIFF
--- a/parse_players.sh
+++ b/parse_players.sh
@@ -6,17 +6,16 @@ pup_path='.competitors tbody tr.Table2__tr json{}'
 /home/sam/bin/pup "$pup_path" | \
     /home/sam/bin/jq '.[1:]' | \
     /home/sam/bin/jq '[.[] | {
-        player: .children[1].children[1].text,
+        player: .children[2].children[1].text,
         pos: .children[0].text,
         r1: .children[5].text,
         r2: .children[6].text,
         r3: .children[7].text,
         r4: .children[8].text,
         tot: .children[9].text,
-        to_par: .children[2].text,
+        to_par: .children[3].text,
         today: .children[3].text,
         thru: .children[4].text,
-        link: .children[1].children[1].href,
-        country_flag_image: .children[1].children[0].src
+        link: .children[2].children[1].href,
+        country_flag_image: .children[2].children[0].src
     }]'
-


### PR DESCRIPTION
Just made adjustments to the array keys to account for the new table column added to the leaderboard today. 

Probably should check for that and handle it more automatically for when the column doesn't exist on the first day next year, but this was the quick fix for now. 

Fixes #2 